### PR TITLE
Fxing: Serializer of Edit Mode always creates Turtle

### DIFF
--- a/src/app/parser.js
+++ b/src/app/parser.js
@@ -69,7 +69,7 @@ function getSerializer(format, baseIRI) {
         case "text/nt":
         case "text/turtle":
         case "text/n3":
-            serializer = new N3StreamWriter(null, {
+            serializer = new N3StreamWriter({
                 baseIRI: baseIRI,
                 format: format
             });


### PR DESCRIPTION
When editing a document in Edit Mode (in Developer Mode), the resulting PUT requests always has a Turtle payload when the serializer of N3.js is used. This is because `N3StreamWriter` takes `options` (where the target format is passed) as a first argument not as a second argument as done in [parser.js#L72](https://github.com/kianschmalenbach/rdf-browser/blob/6e522a3ddaee74ede8c3b7fe21e61009a0fd78ff/src/app/parser.js#L72). Commit [85c6bb8](https://github.com/dschraudner/rdf-browser/commit/85c6bb879b1e18e7f006c7e5f71368c5ed74cdfb) fixes this.