### PR TITLE
Fix/relative uri display

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   "dependencies": {
     "dot-prop": "^5.3.0",
     "jsonld-streaming-parser": "^5.0.1",
-    "jsonld-streaming-serializer": "^1.2.0",
+    "jsonld-streaming-serializer": "^4.0.0",
     "n3": "^1.26.0",
     "npm": "latest",
     "rdfxml-streaming-parser": "^3.2.0"

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "./script/build.sh",
-    "browserify": "esbuild src/main.js --bundle --outfile=build/main.js --global-name=app --platform=browser --alias:stream=stream-browserify --alias:buffer=buffer --alias:events=events",
+    "browserify": "esbuild src/main.js --bundle --outfile=build/main.js --global-name=app --platform=browser --alias:stream=stream-browserify --alias:buffer=buffer --alias:events=events --inject:src/process-inject.js",
     "release": "./script/release.sh"
   },
   "repository": {
@@ -25,6 +25,7 @@
     "esbuild": "^0.27.4",
     "events": "^3.3.0",
     "node-forge": "^1.3.1",
+    "process": "^0.11.10",
     "stream-browserify": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,18 +13,15 @@
     "url": "https://github.com/kianschmalenbach/rdf-browser.git"
   },
   "dependencies": {
-    "dot-prop": "^5.3.0",
     "jsonld-streaming-parser": "^5.0.1",
     "jsonld-streaming-serializer": "^4.0.0",
     "n3": "^1.26.0",
-    "npm": "latest",
     "rdfxml-streaming-parser": "^3.2.0"
   },
   "devDependencies": {
     "buffer": "^6.0.3",
     "esbuild": "^0.27.4",
     "events": "^3.3.0",
-    "node-forge": "^1.3.1",
     "process": "^0.11.10",
     "stream-browserify": "^3.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "./script/build.sh",
-    "browserify": "esbuild src/main.js --bundle --outfile=build/main.js --global-name=app --platform=browser --alias:stream=stream-browserify --alias:buffer=buffer --alias:events=events --inject:src/process-inject.js",
+    "browserify": "esbuild src/main.js --bundle --minify --outfile=build/main.js --global-name=app --platform=browser --alias:stream=stream-browserify --alias:buffer=buffer --alias:events=events --inject:src/process-inject.js",
     "release": "./script/release.sh"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "license": "MIT",
   "scripts": {
     "build": "./script/build.sh",
-    "browserify": "browserify -s app -o build/main.js src/main.js",
+    "browserify": "esbuild src/main.js --bundle --outfile=build/main.js --global-name=app --platform=browser --alias:stream=stream-browserify --alias:buffer=buffer --alias:events=events",
     "release": "./script/release.sh"
   },
   "repository": {
@@ -21,7 +21,10 @@
     "rdfxml-streaming-parser": "^1.3.6"
   },
   "devDependencies": {
-    "browserify": "^16.5.2",
-    "node-forge": "^1.3.1"
+    "buffer": "^6.0.3",
+    "esbuild": "^0.27.4",
+    "events": "^3.3.0",
+    "node-forge": "^1.3.1",
+    "stream-browserify": "^3.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "dot-prop": "^5.3.0",
     "jsonld-streaming-parser": "^2.1.0",
     "jsonld-streaming-serializer": "^1.2.0",
-    "n3": "^1.6.3",
+    "n3": "^1.26.0",
     "npm": "latest",
     "rdfxml-streaming-parser": "^1.3.6"
   },

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   },
   "dependencies": {
     "dot-prop": "^5.3.0",
-    "jsonld-streaming-parser": "^2.1.0",
+    "jsonld-streaming-parser": "^5.0.1",
     "jsonld-streaming-serializer": "^1.2.0",
     "n3": "^1.26.0",
     "npm": "latest",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "jsonld-streaming-serializer": "^1.2.0",
     "n3": "^1.26.0",
     "npm": "latest",
-    "rdfxml-streaming-parser": "^1.3.6"
+    "rdfxml-streaming-parser": "^3.2.0"
   },
   "devDependencies": {
     "buffer": "^6.0.3",

--- a/src/app/interceptor.js
+++ b/src/app/interceptor.js
@@ -169,7 +169,14 @@ async function rewriteResponse(cl, details, encoding, format, redirect) {
         {name: "Pragma", value: "no-cache"},
         {name: "Expires", value: "0"}
     ];
-    const url = redirect ? details.responseHeaders.find(h => h.name.toLowerCase() === "location").value : details.url;
+    let url = details.url;
+    if (redirect) {
+        const location = details.responseHeaders.find(h => h.name.toLowerCase() === "location");
+        // Location may be a relative reference (RFC 7231 §7.1.2); resolve it
+        // against the request URL, otherwise fetch() below would resolve it
+        // against the extension origin and never reach the origin server.
+        url = location ? new URL(location.value, details.url).href : details.url;
+    }
     if (options.contentScript) {
         const req = requests[details.tabId];
         req.url = url;
@@ -188,9 +195,20 @@ async function rewriteResponse(cl, details, encoding, format, redirect) {
     const filter = browser.webRequest.filterResponseData(details.requestId);
     let stream;
     if (redirect && url !== details.url) {
-        const response = await fetch(url);
-        if (!response.ok)
+        let response;
+        try {
+            response = await fetch(url);
+        } catch (e) {
+            // Closing the filter is essential: returning while it is still
+            // attached leaves the original response stream open and the tab
+            // hangs until it times out.
+            filter.close();
             return {};
+        }
+        if (!response.ok) {
+            filter.close();
+            return {};
+        }
         const body = await response.body;
         stream = body.getReader();
     } else

--- a/src/app/serializer.js
+++ b/src/app/serializer.js
@@ -27,7 +27,7 @@ function serializePrefixes(store, html = null) {
         html.appendChild(prefixElement);
         html.appendChild(doubleColonElement);
         html.appendChild(document.createTextNode(" "));
-        html.appendChild(prefix.value.createHtml(true, true));
+        html.appendChild(prefix.value.createHtml(true, true, store.baseURL));
         html.appendChild(document.createTextNode(" ."));
         return html;
     }

--- a/src/bdo/resource.js
+++ b/src/bdo/resource.js
@@ -81,12 +81,21 @@ class URI extends Resource {
         const html = document.createElement("span");
         const link = document.createElement("a");
         let uriValue = this.value;
-        if (baseURL !== "" && this.value === baseURL)
-            uriValue = "";
-        else if ((this.value.replace("https", "http").split("#"))[0] ===
-            (baseURL.replace("https", "http").split("#")[0]))
-            uriValue = this.value.substring(this.value.split("#")[0].length);
-        link.setAttribute("href", encodeURI(uriValue));
+        if (baseURL !== "") {
+            try {
+                const thisNorm = new URL(this.value).href;
+                const baseNorm = new URL(baseURL).href;
+                if (thisNorm === baseNorm)
+                    uriValue = "";
+                else if (new URL(this.value.split("#")[0]).href === new URL(baseURL.split("#")[0]).href)
+                    uriValue = this.value.substring(this.value.split("#")[0].length);
+            } catch(e) {
+                if ((this.value.replace("https", "http").split("#"))[0] ===
+                    (baseURL.replace("https", "http").split("#")[0]))
+                    uriValue = this.value.substring(this.value.split("#")[0].length);
+            }
+        }
+        link.setAttribute("href", uriValue);
         if (!forPrefix && this.prefix !== null) {
             html.setAttribute("class", "postfix");
             const prefixElement = document.createElement("span");

--- a/src/bdo/resource.js
+++ b/src/bdo/resource.js
@@ -101,13 +101,13 @@ class URI extends Resource {
         } else {
             html.setAttribute("class", "uri");
             link.appendChild(document.createTextNode("<"));
-            link.appendChild(document.createTextNode(this.value));
+            link.appendChild(document.createTextNode(uriValue));
             link.appendChild(document.createTextNode(">"));
             html.appendChild(link);
             if (forPrefix)
                 return html;
             if (this.html === null)
-                this.representationLength = this.value.length + 2;
+                this.representationLength = uriValue.length + 2;
         }
         if (this.html === null)
             this.html = html;

--- a/src/bdo/resource.js
+++ b/src/bdo/resource.js
@@ -69,7 +69,7 @@ class URI extends Resource {
             return;
         for (const prefix of prefixes) {
             if (this.value.length > prefix.value.value.length && this.value.includes(prefix.value.value) &&
-                this.value.substr(prefix.value.value.length, this.value.length).match(/^[a-zA-Z0-9]+$/)) {
+                this.value.substr(prefix.value.value.length, this.value.length).match(/^[a-zA-Z0-9_][a-zA-Z0-9_\-.]*[a-zA-Z0-9_\-]$|^[a-zA-Z0-9_]$/)) {
                 this.prefix = prefix;
                 prefix.used = true;
                 return;

--- a/src/bdo/resource.js
+++ b/src/bdo/resource.js
@@ -81,7 +81,9 @@ class URI extends Resource {
         const html = document.createElement("span");
         const link = document.createElement("a");
         let uriValue = this.value;
-        if ((this.value.replace("https", "http").split("#"))[0] ===
+        if (baseURL !== "" && this.value === baseURL)
+            uriValue = "";
+        else if ((this.value.replace("https", "http").split("#"))[0] ===
             (baseURL.replace("https", "http").split("#")[0]))
             uriValue = this.value.substring(this.value.split("#")[0].length);
         link.setAttribute("href", encodeURI(uriValue));

--- a/src/process-inject.js
+++ b/src/process-inject.js
@@ -1,0 +1,1 @@
+export { default as process } from "process/browser";


### PR DESCRIPTION
## Summary                                                
            
  - Replace browserify with esbuild; add process browser shim
  - Remove unused dependencies: dot-prop, node-forge
  - Enable minification
  - Update RDF libraries: n3 1.26, rdfxml-streaming-parser 3.2, jsonld-streaming-parser 5.0, jsonld-streaming-serializer 4.0 (fixes kianschmalenbach#27, kianschmalenbach#36)
  - Fix double percent-encoding of IRIs in href attributes (fixes kianschmalenbach#41)
  - Display relative URI references in rendered Turtle: <> for the document URI, <#fragment> for same-document hash URIs, <#> in @prefix namespace declarations
  - Allow underscores, hyphens, and dots in prefixed name local parts to match Turtle PN_LOCAL spec (fixes kianschmalenbach#29)
